### PR TITLE
Fix the heading in the CODE_OF_CONDUCT.md file.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-#Contributor Code of Conduct
+# Contributor Code of Conduct
 
 As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 


### PR DESCRIPTION
# The reason for this contribution

The first line of your code of conduct has a typo/error, regarding the space between the hashtag and the heading text.
I suggest that you add a space after the hashtag at the first line because it won't render correctly if you don't have a space as a separator between the hashtag and text.

# The comparison

## Before
Here is the rendered blob before:
(note the first line does not show up as a regular heading.)

![before-shopfy](https://user-images.githubusercontent.com/95201376/155189672-2e52ddda-b1b9-4950-b012-4f3196332072.png)

## After

The first line is displayed correctly now.
This is what it would look like if you decided to accept my contribution:

![Screenshot 2022-02-22 12 53 46 PM](https://user-images.githubusercontent.com/95201376/155190726-33d185bb-e36a-4aa8-ad16-dba1e73a656e.png)

This is my first open-source contribution, so if I did anything wrong, please inform me so that I could do better next time.
